### PR TITLE
Add a test to demonstrate a bug

### DIFF
--- a/raft/states/leader.py
+++ b/raft/states/leader.py
@@ -11,6 +11,8 @@ logger = logging.getLogger("raft")
 
 
 class Leader(State):
+    TEST_ONLY_DISABLE_SEND_LOOP = False
+
     def __init__(self):
         def default_next_index() -> int:
             return self._server._lastLogIndex + 1
@@ -18,7 +20,8 @@ class Leader(State):
         self._nextIndex = defaultdict(default_next_index)
         self._matchIndex = defaultdict(int)
         self.timer = None  # Used by followers/candidates for leader timeout
-        asyncio.create_task(self.append_entries_loop())
+        if not self.TEST_ONLY_DISABLE_SEND_LOOP:
+            asyncio.create_task(self.append_entries_loop())
 
     def __repr__(self):
         return (
@@ -30,7 +33,10 @@ class Leader(State):
         self.leader = self._server._name
         logger.info(f"{self._server._name}: New Leader")
         loop = asyncio.get_event_loop()
-        heart_beat_task = loop.create_task(self._send_heart_beat())
+        if not self.TEST_ONLY_DISABLE_SEND_LOOP:
+            heart_beat_task = loop.create_task(self._send_heart_beat())
+        else:
+            heart_beat_task = loop.create_task(self._send_one_heart_beat())
 
         for n in self._server._neighbors:
             # With ZeroMQServer we use n.name, but for ZREServer, neighbor is an id
@@ -52,7 +58,7 @@ class Leader(State):
             entry.index = self._server._lastLogIndex
         return self, None
 
-    async def on_response_received(self, message):
+    async def on_response_received(self, message, test_original_message=None):
         original_message = None
         if hasattr(self._server, "_outstanding_index"):
             if message.id in self._server._outstanding_index:
@@ -63,6 +69,9 @@ class Leader(State):
                 return self, None
         else:
             num_entries = 0
+            if test_original_message:
+                original_message = test_original_message
+                num_entries = len(test_original_message.entries)
 
         # Was the last AppendEntries good?
         if not message.response:
@@ -98,7 +107,7 @@ class Leader(State):
 
         return self, None
 
-    async def _send_heart_beat(self):
+    async def _send_one_heart_beat(self):
         message = AppendEntriesMessage(
             self._server._name,
             None,
@@ -110,6 +119,9 @@ class Leader(State):
             leader_commit=self._server._commitIndex,
         )
         await self._server.send_message(message)
+
+    async def _send_heart_beat(self):
+        await self._send_one_heart_beat()
 
         async def schedule_another_beat():
             await asyncio.sleep(HEART_BEAT_INTERVAL)

--- a/raft/states/leader.py
+++ b/raft/states/leader.py
@@ -101,9 +101,13 @@ class Leader(State):
                     self._matchIndex[message.sender] + 1,
                 )
                 logger.debug(f"Advanced {message.sender} by {num_entries}")
-                self._server._commitIndex = statistics.median_low(
-                    self._matchIndex.values()
-                )
+                new_commit_index = statistics.median_low(self._matchIndex.values())
+                if (
+                    self._server._log[new_commit_index].term
+                    == self._server._currentTerm
+                    and new_commit_index > self._server._commitIndex
+                ):
+                    self._server._commitIndex = new_commit_index
 
         return self, None
 

--- a/raft/states/state.py
+++ b/raft/states/state.py
@@ -34,7 +34,9 @@ class State:
         # Is the messages.term < ours? If so we need to tell
         #   them this so they don't get left behind.
         elif message.term < self._server._currentTerm:
-            await self._send_response_message(message, yes=False)
+            if _type != BaseMessage.MessageType.Response:
+                # Do not send a response to a response
+                await self._send_response_message(message, yes=False)
             return self, None
 
         if _type == BaseMessage.MessageType.AppendEntries:

--- a/tests/test_LeaderServer.py
+++ b/tests/test_LeaderServer.py
@@ -90,5 +90,85 @@ class TestLeaderServer(unittest.IsolatedAsyncioTestCase):
         # self.assertTrue(mock.on_leader_timeout.called)
 
 
+class TestLeaderServerRaftPDF(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        followers = []
+        for i in range(1, 5):
+            board = MemoryBoard()
+            state = Follower(timeout=1)
+            followers.append(Server(i, state, [], board, []))
+
+        board = MemoryBoard()
+        state = Leader()
+
+        self.leader = Server(0, state, [], board, followers)
+
+        for i in followers:
+            i._neighbors.append(self.leader)
+
+        # Consume the heart beat message sent from set_server()
+        for i in self.leader._neighbors:
+            await i.on_message(await i._messageBoard.get_message())
+
+    async def _perform_heart_beat(self):
+        await self.leader._state._send_heart_beat()
+        for i in self.leader._neighbors:
+            await i.on_message(await i._messageBoard.get_message())
+
+        for _, i in self.leader._messageBoard._board._queue:
+            await self.leader.on_message(i)
+
+    async def test_raft_fig8(self):
+        leader = self.leader
+
+        leader._commitIndex = 1
+        leader._currentTerm = 1
+        log_entry_index1 = LogEntry(term=1, index=1, value=1)
+        leader._log.append(log_entry_index1)
+        for i in range(4):
+            leader._neighbors[i]._log.append(log_entry_index1)
+            leader._state._nextIndex[i] = 1
+            leader._state._matchIndex[i] = 1
+
+        leader._neighbors[3]._log.append(LogEntry(term=3, index=2, value=3))
+        leader._lastLogIndex = 1
+        leader._lastLogTerm = 1
+
+        await self._perform_heart_beat()
+
+        # Consume all messages
+        while len(self.leader._messageBoard._board._queue):
+            i = await self.leader._messageBoard.get_message()
+            await self.leader.on_message(i)
+
+        log_entry_index2 = LogEntry(term=2, index=2, value=2)
+        leader._log.append(log_entry_index2)
+        msg = AppendEntriesMessage(
+            0,
+            None,
+            1,
+            prev_log_index=1,
+            prev_log_term=1,
+            leader_commit=1,
+            entries=[log_entry_index2],
+        )
+
+        await leader.send_message(msg)
+
+        for i in leader._neighbors[0:3]:
+            await i.on_message(await i._messageBoard.get_message())
+
+        leader._commitIndex = 1
+        leader._currentTerm = 4
+        leader._log.append(LogEntry(term=4, index=3, value=4))
+
+        for i in range(3):
+            await leader._state.on_response_received(
+                await leader._messageBoard.get_message(), msg
+            )
+
+        self.assertEqual(leader._commitIndex, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is specified by fig 8 in raft paper

Some improvements to leader code so we disable
background chatter for testing purposes. This
include disabling the append entries loop and
heart beat tasks so we can control the flow of
messages.