### PR TITLE
Persist quorum state in the log itself

### DIFF
--- a/raft/messages/append_entries.py
+++ b/raft/messages/append_entries.py
@@ -11,6 +11,8 @@ from .base import BaseMessage
 class Command(IntEnum):
     PUT = 0
     GET = 1
+    QUORUM_PUT = 2
+    QUORUM_GET = 3
 
 
 @deserialize

--- a/raft/servers/server.py
+++ b/raft/servers/server.py
@@ -65,6 +65,8 @@ class Server:
         self._neighbors.remove(neighbor)
         self._total_nodes = len(self._neighbors) + 1
 
+    async def quorum_set(self, neighbor: str, op: str) -> None:
+        pass
 
 class ZeroMQServer(Server):
     "This implementation is suitable for single process testing"


### PR DESCRIPTION
Some implementations choose an external storage service.
This makes the log self contained.

Also increment term on quorum update